### PR TITLE
chore: fix comment in EthPool interface

### DIFF
--- a/contracts/interfaces/ILiquidityEthPool.sol
+++ b/contracts/interfaces/ILiquidityEthPool.sol
@@ -52,7 +52,7 @@ interface ILiquidityEthPool {
 
     /// @notice Get withdraw requests for an account
     /// @param account User account to check
-    /// @return minCycle Cycle - block number - that must be active before withdraw is allowed, amount Token amount requested
+    /// @return minCycle Cycle - index - that must be active before withdraw is allowed, amount Token amount requested
     function requestedWithdrawals(address account) external view returns (uint256, uint256);
 
     /// @notice Pause deposits on the pool. Withdraws still allowed


### PR DESCRIPTION
Comments currently show requestedWithdrawals as returning a block number when it actually returns an index